### PR TITLE
Allow for creation of environmental variables for self-hosting/and instance on a different domain/google cloud project

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ The server that stores all the encrypted sharable drawings from [Excalidraw](htt
 
 Get the [`service key`](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) as JSON and store it under `keys` directory with the name of the project ID.
 
+### Environment Variables
+
+| Variable                   | Description                                      | Default Value                                                                   | Required |
+| -------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------- | -------- |
+| `GOOGLE_CLOUD_PROJECT`     | Google Cloud project ID                          | `excalidraw-json-dev`                                                           | No       |
+| `GOOGLE_CLOUD_BUCKET_NAME` | Google Cloud Storage bucket name                 | `excalidraw-json.appspot.com` (prod) or `excalidraw-json-dev.appspot.com` (dev) | No       |
+| `NODE_ENV`                 | Environment mode                                 | -                                                                               | No       |
+| `ALLOW_ORIGINS`            | Comma-separated list of allowed origins for CORS | Default allowed origins list                                                    | No       |
+| `PORT`                     | Port number for the server                       | `8080`                                                                          | No       |
+
 ### Commands
 
 ```

--- a/index.ts
+++ b/index.ts
@@ -8,9 +8,9 @@ import * as path from "path";
 const PROJECT_NAME = process.env.GOOGLE_CLOUD_PROJECT || "excalidraw-json-dev";
 const PROD = PROJECT_NAME === "excalidraw-json";
 const LOCAL = process.env.NODE_ENV !== "production";
-const BUCKET_NAME = PROD
-  ? "excalidraw-json.appspot.com"
-  : "excalidraw-json-dev.appspot.com";
+const BUCKET_NAME =
+  process.env.GOOGLE_CLOUD_BUCKET_NAME ||
+  (PROD ? "excalidraw-json.appspot.com" : "excalidraw-json-dev.appspot.com");
 
 const FILE_SIZE_LIMIT = 2 * 1024 * 1024;
 const storage = new Storage(
@@ -25,13 +25,22 @@ const storage = new Storage(
 const bucket = storage.bucket(BUCKET_NAME);
 const app = express();
 
-let allowOrigins = [
-  "excalidraw.vercel.app",
-  "https://dai-shi.github.io",
-  "https://excalidraw.com",
-  "https://www.excalidraw.com",
-  "https://math.preview.excalidraw.com",
-];
+let allowOrigins: string[] = [];
+
+if (process.env.ALLOW_ORIGINS) {
+  allowOrigins = process.env.ALLOW_ORIGINS.split(",").map((origin) =>
+    origin.trim()
+  );
+} else {
+  allowOrigins = [
+    "excalidraw.vercel.app",
+    "https://dai-shi.github.io",
+    "https://excalidraw.com",
+    "https://www.excalidraw.com",
+    "https://math.preview.excalidraw.com",
+  ];
+}
+
 if (!PROD) {
   allowOrigins.push("http://localhost:");
 }


### PR DESCRIPTION
Currently the allowedOrigins are hard-coded. This PR adds the ability to customize this and a few other options via env vars.

This was prompted because the re-write removed the ability for a self hosted instance of excalidraw to export links. 

Fix in previous version here: https://github.com/excalidraw/excalidraw/issues/600
Relevant code in new version: https://github.com/excalidraw/excalidraw-store/blob/f9270d935689caf39645fd5fe3ca5dcf8bfd6ca8/index.ts#L28-L52

My ideal would be to re-open cors so self-hosted versions can export using the excalidraw.com services.

My second best solution is this PR, coupled with a default removal of the [hosted service env vars](https://github.com/excalidraw/excalidraw/blob/c6f8ef9ad26fdfc4cc535e161819dda70c4e3a72/.env.production#L4) to avoid confusion.